### PR TITLE
added missing checkAck and send_ack|nack routines

### DIFF
--- a/driver/i2c_master.h
+++ b/driver/i2c_master.h
@@ -76,4 +76,7 @@ uint8 i2c_master_readByte(void);
 void i2c_master_writeByte(uint8 wrdata);
 uint8 i2c_slave_exists( uint8 i2caddr );
 
+bool i2c_master_checkAck(void);
+void i2c_master_send_ack(void);
+void i2c_master_send_nack(void);
 #endif

--- a/i2c_master.c
+++ b/i2c_master.c
@@ -296,3 +296,43 @@ uint8 i2c_slave_exists( uint8 i2caddr ){
 	 
 }
 
+
+/******************************************************************************
+* FunctionName : i2c_master_checkAck
+* Description  : get dev response
+* Parameters   : NONE
+* Returns      : true : get ack ; false : get nack
+*******************************************************************************/
+bool ICACHE_FLASH_ATTR
+i2c_master_checkAck(void)
+{
+    if(i2c_master_getAck()){
+        return FALSE;
+    }else{
+        return TRUE;
+    }
+}
+
+/******************************************************************************
+* FunctionName : i2c_master_send_ack
+* Description  : response ack
+* Parameters   : NONE
+* Returns      : NONE
+*******************************************************************************/
+void ICACHE_FLASH_ATTR
+i2c_master_send_ack(void)
+{
+    i2c_master_setAck(0x0);
+}
+/******************************************************************************
+* FunctionName : i2c_master_send_nack
+* Description  : response nack
+* Parameters   : NONE
+* Returns      : NONE
+*******************************************************************************/
+void ICACHE_FLASH_ATTR
+i2c_master_send_nack(void)
+{
+    i2c_master_setAck(0x1);
+}
+


### PR DESCRIPTION
I included your version of the driver when I used your SSD1306, thanks! btw.   Then I went to use another driver for a DS3231, but it used the missing routines found in the original IoT version.  Seemed to be a simple re-add.
